### PR TITLE
fix getElevationGain implementation

### DIFF
--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -32,9 +32,9 @@ export function formatTime(miles) {
 
 export function getElevationGain(profile) {
   let totalElevGain = 0;
-  profile.forEach((p, idx) => {
-    if (idx < profile.length - 1 && profile[idx][1] < profile[idx + 1][1]) {
-      totalElevGain += profile[idx + 1][1] - profile[idx][1];
+  profile.forEach((_, idx) => {
+    if (idx < profile.length - 1 && profile[idx]['elevation'] < profile[idx + 1]['elevation']) {
+      totalElevGain += profile[idx + 1]['elevation'] - profile[idx]['elevation'];
     }
   });
 

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -31,13 +31,15 @@ export function formatTime(miles) {
 }
 
 export function getElevationGain(profile) {
+  // Compute the sum of all the positive elevation gain segments along the route
+  // profile is a list of objects with "elevation" and "distance" properties, each corresponding to a path segment
   let totalElevGain = 0;
-  profile.forEach((_, idx) => {
-    if (idx < profile.length - 1 && profile[idx]['elevation'] < profile[idx + 1]['elevation']) {
-      totalElevGain += profile[idx + 1]['elevation'] - profile[idx]['elevation'];
+  for (let idx = 0; idx < (profile.length - 1); idx++) {
+    const elevationStep = profile[idx + 1]['elevation'] - profile[idx]['elevation']
+    if (elevationStep > 0) {
+      totalElevGain += elevationStep
     }
-  });
-
+  }
   return totalElevGain;
 }
 


### PR DESCRIPTION
I found a bug in Bikesy production, where the getElevationGain function was always returning `0` because of an incorrect assumption about the type of the input variable,`profile`. The role of this function is to count to the total elevation gain along a route, by iterating through the list of path segments, checking if the segment is a net climb, and if so adding it to a tally. But when iterating through the `profile` array, it was trying to access data on each element in the array with index `1`, as if each element was a list. But upon inspection, each element is an object. 

I first changed the data access pattern to use the string key to access the property on an object. I then refactored the function to be more readable.


## Testing

Bikesy.com:

![Screen Shot 2021-11-06 at 2 48 20 PM](https://user-images.githubusercontent.com/2433182/140624902-dea804f5-4607-4239-8f87-27e20ddf7f3c.png)

On this branch:
![Screen Shot 2021-11-06 at 2 48 41 PM](https://user-images.githubusercontent.com/2433182/140624905-b3bec16f-6fa9-4875-bddb-6292290b40f9.png)

Also, I did a test replacing `profile` with an empty list and confirmed that nothing crashed. It just rendered "0 feet of total climbing"
