### PR TITLE
Break out MapLayers component and hide by default if isMobile

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -9,6 +9,7 @@ import {
   updatePath,
   updateMapSize,
 } from 'lib/map';
+import MapLayers from 'components/MapLayers';
 
 const Map = ({
   isMobile,
@@ -20,8 +21,6 @@ const Map = ({
   const startLocation = useSelector((state) => state.search.startLocation);
   const endLocation = useSelector((state) => state.search.endLocation);
   const path = useSelector((state) => state.search.path);
-
-  const [legendVisible, setLegendVisible] = useState(!isMobile);
 
   const startLocationRef = useRef(startLocation);
   const endLocationRef = useRef(endLocation);
@@ -46,10 +45,6 @@ const Map = ({
         assignEndLocation(latlng);
       }
     }
-  };
-
-  const toggleLegendVisibility = () => {
-    setLegendVisible(!legendVisible);
   };
 
   useEffect(() => {
@@ -84,40 +79,7 @@ const Map = ({
         />
       </div>
       <div className="map" id="map" style={{ height: `${height}px` }}></div>
-      {legendVisible ? (
-        <div className="map-layers d-print-none">
-          <div className="close-box" onClick={toggleLegendVisibility}>
-            &minus;
-          </div>
-          <div>
-            <div
-              className="map-legend-item"
-              title="paved, separated (off the street) bikeways"
-            >
-              <div className="map-legend-icon class1"></div>
-              <label>Multi-use Path</label>
-            </div>
-            <div
-              className="map-legend-item"
-              title="dedicated on-street bikeways, marked by striping on pavement"
-            >
-              <div className="map-legend-icon class2"></div>
-              <label>Bike Lane</label>
-            </div>
-            <div
-              className="map-legend-item"
-              title="on-street routes signed for bicyclists"
-            >
-              <div className="map-legend-icon class3"></div>
-              <label>Bike Route</label>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <div className="map-layers-open-box" onClick={toggleLegendVisibility}>
-          Toggle Map Legend
-        </div>
-      )}
+      <MapLayers isInitiallyVisible={!isMobile} />
     </div>
   );
 };

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -79,9 +79,7 @@ const Map = ({
         />
       </div>
       <div className="map" id="map" style={{ height: `${height}px` }}></div>
-      {isMobile !== undefined && (
-        <MapLayers isInitiallyVisible={!isMobile} />
-      )}
+      {isMobile !== undefined && <MapLayers isInitiallyVisible={!isMobile} />}
     </div>
   );
 };

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -79,7 +79,9 @@ const Map = ({
         />
       </div>
       <div className="map" id="map" style={{ height: `${height}px` }}></div>
-      <MapLayers isInitiallyVisible={!isMobile} />
+      {isMobile !== undefined && (
+        <MapLayers isInitiallyVisible={!isMobile} />
+      )}
     </div>
   );
 };

--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 
 const MapLayers = ({ isInitiallyVisible }) => {
   const [isVisible, setisVisible] = useState(isInitiallyVisible);

--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -1,14 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
 
-const MapLayers = (isInitiallyVisible) => {
+const MapLayers = ({ isInitiallyVisible }) => {
   const [isVisible, setisVisible] = useState(isInitiallyVisible);
   const toggleLegendVisibility = () => {
     setisVisible(!isVisible);
   };
 
   return (
-      isVisible ? (
-      <div className = "map-layers d-print-none" >
+    isVisible ? (
+      <div className="map-layers d-print-none" >
         <div className="close-box" onClick={toggleLegendVisibility}>
           &minus;
         </div>
@@ -37,11 +37,11 @@ const MapLayers = (isInitiallyVisible) => {
         </div>
       </div >
     ) : (
-    <div className="map-layers-open-box" onClick={toggleLegendVisibility}>
-      Toggle Map Legend
-    </div>
+      <div className="map-layers-open-box" onClick={toggleLegendVisibility}>
+        Toggle Map Legend
+      </div>
+    )
   )
-)
 }
 
 export default MapLayers

--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -6,42 +6,37 @@ const MapLayers = ({ isInitiallyVisible }) => {
     setisVisible(!isVisible);
   };
 
-  return (
-    isVisible ? (
-      <div className="map-layers d-print-none" >
-        <div className="close-box" onClick={toggleLegendVisibility}>
-          &minus;
-        </div>
-        <div>
-          <div
-            className="map-legend-item"
-            title="paved, separated (off the street) bikeways"
-          >
-            <div className="map-legend-icon class1"></div>
-            <label>Multi-use Path</label>
-          </div>
-          <div
-            className="map-legend-item"
-            title="dedicated on-street bikeways, marked by striping on pavement"
-          >
-            <div className="map-legend-icon class2"></div>
-            <label>Bike Lane</label>
-          </div>
-          <div
-            className="map-legend-item"
-            title="on-street routes signed for bicyclists"
-          >
-            <div className="map-legend-icon class3"></div>
-            <label>Bike Route</label>
-          </div>
-        </div>
-      </div >
-    ) : (
-      <div className="map-layers-open-box" onClick={toggleLegendVisibility}>
-        Toggle Map Legend
+  return isVisible ? (
+    <div className="map-layers d-print-none">
+      <div className="close-box" onClick={toggleLegendVisibility}>
+        &minus;
       </div>
-    )
-  )
-}
+      <div>
+        <div
+          className="map-legend-item"
+          title="paved, separated (off the street) bikeways"
+        >
+          <div className="map-legend-icon class1"></div>
+          <label>Multi-use Path</label>
+        </div>
+        <div
+          className="map-legend-item"
+          title="dedicated on-street bikeways, marked by striping on pavement"
+        >
+          <div className="map-legend-icon class2"></div>
+          <label>Bike Lane</label>
+        </div>
+        <div className="map-legend-item" title="on-street routes signed for bicyclists">
+          <div className="map-legend-icon class3"></div>
+          <label>Bike Route</label>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <div className="map-layers-open-box" onClick={toggleLegendVisibility}>
+      Toggle Map Legend
+    </div>
+  );
+};
 
-export default MapLayers
+export default MapLayers;

--- a/src/components/MapLayers.js
+++ b/src/components/MapLayers.js
@@ -1,0 +1,47 @@
+import { useState, useEffect, useRef } from 'react';
+
+const MapLayers = (isInitiallyVisible) => {
+  const [isVisible, setisVisible] = useState(isInitiallyVisible);
+  const toggleLegendVisibility = () => {
+    setisVisible(!isVisible);
+  };
+
+  return (
+      isVisible ? (
+      <div className = "map-layers d-print-none" >
+        <div className="close-box" onClick={toggleLegendVisibility}>
+          &minus;
+        </div>
+        <div>
+          <div
+            className="map-legend-item"
+            title="paved, separated (off the street) bikeways"
+          >
+            <div className="map-legend-icon class1"></div>
+            <label>Multi-use Path</label>
+          </div>
+          <div
+            className="map-legend-item"
+            title="dedicated on-street bikeways, marked by striping on pavement"
+          >
+            <div className="map-legend-icon class2"></div>
+            <label>Bike Lane</label>
+          </div>
+          <div
+            className="map-legend-item"
+            title="on-street routes signed for bicyclists"
+          >
+            <div className="map-legend-icon class3"></div>
+            <label>Bike Route</label>
+          </div>
+        </div>
+      </div >
+    ) : (
+    <div className="map-layers-open-box" onClick={toggleLegendVisibility}>
+      Toggle Map Legend
+    </div>
+  )
+)
+}
+
+export default MapLayers

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,8 @@ const IndexPage = () => {
   const [loading, setLoading] = useState(false);
   const [scenario, setScenario] = useState('5');
   const [mobileView, setMobileView] = useState('map');
-  const [isMobile, setIsMobile] = useState();
+  // window width is not known until after the component mounts
+  const [isMobile, setIsMobile] = useState(undefined);
   const [showWelcomeModal, setShowWelcomeModal] = useState(
     appConfig.SHOULD_SHOW_WELCOME_MODAL
   );


### PR DESCRIPTION
Here's a mergeable quickie as I get started on working on a MapLayers component that is customizable on a per-environment basis. The Tahoe MapLayers component is very different from the Bikesy legend, and so splitting it out into its own component will make it easier to add some complexity there. This component can manage its own visibility state.

While I started to do this, I noticed that we initialize the state to the opposite of the initial state of `isMobile`. However, this is not working. The [initial state of isMobile is undefined](https://github.com/brendannee/bikesy/blob/master/src/pages/index.js#L48), and so its negation is always `true`.

We can see the bug by loading bikesy production, reszing the window narrow enough to count as mobile, and refreshing the page. We should expect the legend to be initialized in its collapsed state, but it isn't.

It seems like this regression slipped in [quite a while ago](https://github.com/brendannee/bikesy/commit/9658e95ee2650e3e178b1f9c8c62ab9466104db2#diff-f52e106c74e56af8f124ce009ac3c50f1cf4f78555e86c13c0eb958186e92096L24), when converting from a Class component to Functional component. Since the Tahoe fork is so old, it is still behaving as originally intended 😅 . Previously we measured the window.width when defining the component's class, but now with functional components, we don't have access to `window` at the time when we call `useState`, so we had initialized the boolean to `undefined`. Am I interpreting that right?

This PR restores the intended functionality by deferring initial rendering of the MapLayers component until _after_ the first render of the grandparent IndexPage component, whose call to `useEffect` after mount first sets the value of `isMobile` to a defined boolean value.