### PR TITLE
Tweak elevation profile y domain to better display hills

### DIFF
--- a/src/appConfig/defaults.js
+++ b/src/appConfig/defaults.js
@@ -7,6 +7,7 @@ const config = {
   BIKESY_HIGH_BIKE_SPEED_MPH: 10,
   LOGO_FILENAME_ROOT: 'bikesy-logo',
   LOGO_CLASSNAME: 'logo',
+  ELEVATION_CHART_Y_DOMAIN: [0, 'auto'],
 
   // Expected to be overridden for all regions:
   // TODO consider putting placeholders here to force regional overrides

--- a/src/appConfig/tahoe.js
+++ b/src/appConfig/tahoe.js
@@ -1,4 +1,12 @@
 const config = {
+  // Round elevation chart Y-axis to nearest 1000 feet to make hills more visible.
+  // Previously the range was 0 to max, which made hills imperceptible at high elevations.
+  // Dynamic rounding (vs static values) handles multiple service areas at different elevations
+  // (e.g., Carson City ~4,700 ft vs Tahoe ~6,200 ft vs Echo Summit ~7,400 ft).
+  ELEVATION_CHART_Y_DOMAIN: [
+    (dataMin) => Math.floor(dataMin / 1000) * 1000,
+    (dataMax) => Math.ceil(dataMax / 1000) * 1000,
+  ],
   HILL_ROUTING_OPTIONS: [],
   ROUTE_TYPE_OPTIONS: [
     {

--- a/src/components/Elevation.js
+++ b/src/components/Elevation.js
@@ -8,6 +8,7 @@ import {
   metersToMiles,
   calculateGrade,
 } from 'lib/helper';
+import config from 'appConfig';
 
 const CustomTooltip = ({ active, payload }) => {
   if (active) {
@@ -93,6 +94,7 @@ const Elevation = ({
         />
         <YAxis
           type="number"
+          domain={config.ELEVATION_CHART_Y_DOMAIN}
           label={{
             value: 'Elevation (feet)',
             angle: -90,


### PR DESCRIPTION
This PR changes the elevation profile line chart for the tahoe region only (all other regions remain unchanged). The change is to round the elevation chart Y-axis `domain` to nearest 1000 feet to make hills more visible. Previously the range was 0 to max, which made hills imperceptible at high elevations like Tahoe. This rounding (vs static values) handles multiple service areas at different elevations (e.g., Carson City ~4,700 ft vs Tahoe ~6,200 ft vs Echo Summit ~7,400 ft). Since the rounding is to the nearest 1000, the `domain` generally stays the same within a given area to allow easy comparison between routes.

### BEFORE fix:
<img width="1466" height="797" alt="image" src="https://github.com/user-attachments/assets/80f396e6-8e51-4c32-8ce2-1a49e455164d" />

### AFTER fix:
| Description | Screenshot |
|--------|--------|
| Tahoe | <img width="1468" height="799" alt="Screenshot 2026-02-04 at 5 52 25 PM" src="https://github.com/user-attachments/assets/7bb57c0c-6772-45e6-886f-2ac883b6b02f" /> |
| Carson | <img width="1466" height="789" alt="Screenshot 2026-02-04 at 5 51 34 PM" src="https://github.com/user-attachments/assets/00687ab3-19af-44e4-9890-fd9728afaf4e" /> |
| Carson to Echo | <img width="1463" height="791" alt="Screenshot 2026-02-04 at 5 49 41 PM" src="https://github.com/user-attachments/assets/b2095949-6203-4cb4-a3b3-5cd708b63ed5" />  |