### PR TITLE
Add plowed paths datasetId for Tahoe

### DIFF
--- a/src/appConfig/tahoe.js
+++ b/src/appConfig/tahoe.js
@@ -206,7 +206,19 @@ const config = {
           'line-dasharray': [3, 5],
         },
       },
-      datasetId: undefined, // TODO this layer is derived from several others. Process offline?
+      /*
+      This dataset has been uploaded to Mapbox.
+        - Includes TRPA and Truckee city data
+        - Preprocessing included to only select winter plowed paths
+          - TRPA:
+            - Only include trails with WNT_MAINT == 'YES'
+            - Exclude trails with "MAINT_JURS" == "EL DORADO COUNTY" because they stopped plowing.
+          - Truckee
+            - Only include trails with CLASS == "I", and MAINTBY == "Town of Truckee"
+            - "The trails that we plow in the winter are only those Class I paved trails managed by the Town" - Sarah Kunnen, Engineering Technician, Town Of Truckee
+            - Exclude routes with install dates in the future
+      */
+      datasetId: 'tahoebike/cmod6xwi31ykt1npixuglmko7',
       isInitiallyChecked: false,
     },
   ],


### PR DESCRIPTION
This dataset has been uploaded to Mapbox.
- Includes TRPA and Truckee city data
- Preprocessing included to only select winter plowed paths
  - TRPA:
    - Only include trails with WNT_MAINT == 'YES'
  - Truckee
    - Only include trails with CLASS == "I", and MAINTBY == "Town of Truckee"
    - "The trails that we plow in the winter are only those Class I paved trails managed by the Town" - Sarah Kunnen, Engineering Technician, Town Of Truckee
    - Exclude routes with install dates in the future

<img width="1466" height="837" alt="Screenshot 2026-04-24 at 11 34 12 AM" src="https://github.com/user-attachments/assets/f014b808-bd39-4300-b563-5e3b1f7769df" />